### PR TITLE
Update icip-1.md

### DIFF
--- a/icip-1.md
+++ b/icip-1.md
@@ -290,12 +290,12 @@ operator can transfer tokens of that type belonging to the owner.
 ```
 type TokenIds = {
   #All;
-  #Some: [TokenId];
+  #Some: (TokenId, ?Balance);
 };
 
 type OperatorAction = {
-  #AddOperator: TokenIds;
-  #RemoveOperator: TokenIds;
+  #SetOperator: TokenIds;
+  #RemoveOperator: ?[TokenId];
 };
 
 type OperatorRequest = {
@@ -311,14 +311,14 @@ type OperatorResponse = Result.Result<(), {
 type updateOperator = (requests: [OperatorRequest]) -> async OperatorResponse;
 ```
 
-Add or Remove token operators for the specified token owners and token IDs.
+Update or Remove token operators for the specified token owners, token IDs and balances.
 
 - The entrypoint accepts a list of `OperatorRequest`s. If two different requests
   in the list add and remove an operator for the same token owner and token ID,
   the last command in the list MUST take effect.
 
 - Adding an operator for `#All` token IDs MUST grant permissions to all current
-  and future tokens owned by the owner. Similarly, removing an operator for
+  and future tokens owned by the owner for ALL balances. Similarly, removing an operator for
   `#All` token IDs MUST remove permissions for all current and future tokens.
 
 - It is possible to update operators for a token owner that does not hold any
@@ -338,7 +338,9 @@ owner (`owner == caller`) or be limited to an administrator. If so, the
 ```
 type IsAuthorizedRequest = {
   owner: User;
-  operator: User
+  operator: User;
+  tokenId: TokenId;
+  amount: Balance;
 };
 
 type IsAuthorizedResponse = [Bool];
@@ -347,7 +349,7 @@ type isAuthorized = query (requests: [IsAuthorizedRequest]) -> async IsAuthorize
 ```
 
 Checks whether the specified `operator` principal is authorized to transfer on
-behalf of the `owner` principal.
+behalf of the `owner` principal the token `tokenId` of `amount`.
 
 - Results MUST be consistent with authorization checks in `transfer` operations.
   If `isAuthorized` returns `True` for a given operator and owner pair, then
@@ -359,7 +361,7 @@ behalf of the `owner` principal.
 ##### `getMetadata`
 
 ```
-type Metadata = Text;
+type Metadata = Blob;
 
 type MetadataResponse = Result.Result<[Metadata], {
   #InvalidToken: TokenId;


### PR DESCRIPTION
Reasons for changes:
1) Metadata as Blob instead of Text - This can be mutated from Blob to Text and back using encode functions, and can allow for better on-chain interactivity (e.g. genome sequences for something like Crypto Kitties). Can also represent an encoded JSON string etc
2) Changes to operator actions - replaced AddOperator with SetOperator as SetOperator as it can be used as an update (which can also reduce rights/balances).
3) Added Optional Balance to TokenIds #Some to create an operator balance on a per cycle basis. NULL balance provides access to full balance (including future balance)
4) Changed #RemoveOperator to accept ?[TokenId] as opposed to [TokenIds] to completely remove all rights for a token. This is optional, so use NULL to remove all rights
5) Updated isAuthorizedRequest to include tokenId and a balance.